### PR TITLE
Edit PollapoNotLoggedInError message

### DIFF
--- a/cli/pollapo/misc/github.ts
+++ b/cli/pollapo/misc/github.ts
@@ -60,6 +60,6 @@ export async function fetchArchive(
 
 export class PollapoNotLoggedInError extends Error {
   constructor() {
-    super("Login required.");
+    super("Login required. Run `pollapo login` first.");
   }
 }


### PR DESCRIPTION
pollapo login이 되지 않은 상태에서 pollapo install을 실행할 경우 뜨는 에러 메시지를 좀 더 구체화합니다.