### PR TITLE
Fix typing issue

### DIFF
--- a/codegen/ts/messages.ts
+++ b/codegen/ts/messages.ts
@@ -524,7 +524,7 @@ export function getDefaultTsValueToWireValueCode(
       getFilePath(typePath),
       "encodeBinary",
     );
-    return `{ type: ${WireType}.LengthDelimited, value: ${encodeBinary}(${tsValue}) }`;
+    return `{ type: ${WireType}.LengthDelimited as const, value: ${encodeBinary}(${tsValue}) }`;
   }
 }
 


### PR DESCRIPTION
Since `WireType.LengthDelimited` is infered as `WireType` (expected `WireType.LengthDelimited`), so the return value is infered as `{ type: WireType; value: Uint8Array}`  (expected `LengthDelimited`).

It fixes above issue.