### PR TITLE
[pb] Struct.proto 컴파일 오류 수정

### DIFF
--- a/codegen/ts/messages.ts
+++ b/codegen/ts/messages.ts
@@ -281,10 +281,13 @@ const getEncodeBinaryCode: GetCodeFn = (
       );
       if (schema.kind === "map") {
         return [
-          `  for (const [key, value] of Object.entries(value.${tsName})) {\n`,
-          "    result.push(\n",
-          `      [${fieldNumber}, ${tsValueToWireValueCode}],\n`,
-          "    );\n",
+          "  {\n",
+          `    const fields = Object.entries(value.${tsName});\n`,
+          "    for (const [key, value] of fields) {\n",
+          "      result.push(\n",
+          `        [${fieldNumber}, ${tsValueToWireValueCode}],\n`,
+          "      );\n",
+          "    }\n",
           "  }\n",
         ].join("");
       }


### PR DESCRIPTION
`pb gen ts`를 이용하여 `Struct.proto`를 컴파일 할 경우, `out/messages/google/protobuf/Struct.ts`에 다음과 같은 코드가 생성됩니다:
```typescript
export function encodeBinary(value: Type): Uint8Array {
  const result: WireMessage = [];
  for (const [key, value] of Object.entries(value.fields)) { // variable shadowing
    result.push(
      [1, { type: WireType.LengthDelimited as const, value: serialize([[1, tsValueToWireValueFns.string(key)], [2, { type: WireType.LengthDelimited as const, value: encodeBinary_1(value) }]]) }],
    );
  }
  return serialize(result);
}
```

3번째 줄을 보면 `for` loop 스코프의 `value`가 함수의 파라미터인 `value`를 가리는 문제가 발생합니다.

이 패치는 함수 파라미터의 이름을 `value`에서 `_value`로 바꾸어 문제를 해결합니다.
